### PR TITLE
add APIs for interactive video: get video list, submit graph tree

### DIFF
--- a/bilibili_api/data/api/interactive_video.json
+++ b/bilibili_api/data/api/interactive_video.json
@@ -1,0 +1,22 @@
+{
+  "videolist": {
+    "url": "https://member.bilibili.com/x/web/archive/view",
+    "method": "GET",
+    "verify": true,
+    "params": {
+      "bvid": "bv号"
+    },
+    "comment": "视频列表数据"
+  },
+  "savestory": {
+    "url": "https://api.bilibili.com/x/stein/graph/save",
+    "method": "POST",
+    "verify": true,
+    "data": {
+      "preview": "0 不清楚是什么",
+      "data": "故事树信息",
+      "csrf": "csrf 值"
+    },
+    "comment": "保存故事树"
+  }
+ }

--- a/bilibili_api/video.py
+++ b/bilibili_api/video.py
@@ -35,6 +35,7 @@ from .utils.BytesReader import BytesReader
 from .utils.AsyncEvent import AsyncEvent
 
 API = get_api("video")
+I_VIDEO_API = get_api("interactive_video")
 
 
 class Video:
@@ -863,6 +864,43 @@ class Video:
             "del_media_ids": ",".join(map(lambda x: str(x), del_media_ids)),
         }
         return await request("POST", url=api["url"], data=data, credential=self.credential)
+
+    async def get_interactive_video_list(self):
+      """
+      获取交互视频的分P信息。
+      
+      Returns:
+        dict: 调用 API 返回结果
+      """
+      api = I_VIDEO_API["videolist"]
+      params = {"bvid": self.get_bvid()}
+      return await request("GET", url=api["url"], params=params, credential=self.credential)
+
+    async def save_story_tree(self, story_tree: str):
+      """
+      上传交互视频的情节树。
+
+      Args:
+        story_tree: 情节树的描述，参考 bilibili_storytree.StoryGraph, 需要 Serialize 这个结构
+
+      Returns:
+        dict: 调用 API 返回结果
+      """
+      api = I_VIDEO_API["savestory"]
+      form_data = {"preview": "0", "data": story_tree, "csrf": self.credential.bili_jct}
+      headers = {
+          "User-Agent": "Mozilla/5.0",
+          "Referer": "https://member.bilibili.com",
+          "Content-Encoding" : "gzip, deflate, br",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Accept": "application/json, text/plain, */*"
+      }
+      from urllib import parse
+      data = parse.urlencode(form_data)
+      return await request("POST", url=api["url"], data=data,
+                           headers=headers,
+                           no_csrf=True,
+                           credential=self.credential)
 
 
 class VideoOnlineMonitor(AsyncEvent):

--- a/examples/best_story.py
+++ b/examples/best_story.py
@@ -1,0 +1,16 @@
+from bilibili_storytree import StoryGraph, ScriptNode
+
+class Oscar:
+  def __init__(self, videos: dict, aid: int):
+    self.videos = videos
+    # Create graph
+    self.graph = StoryGraph(aid=aid)
+
+  def gen_simple_graph(self, root_title: str):
+    # 建情节树：只有一个分支剧情模块
+    root_video = self.videos[root_title] 
+    n_root = ScriptNode(node_type="videoNode", isRoot=True)
+    n_root.set_video(video=root_video)
+    self.graph._update_script_nodes([n_root]) # update graph["script"]["nodes"]
+    self.graph._sync_nodes() # create graph["nodes"]
+    self.graph._sync_vars() # create graph["regional_vars"]

--- a/examples/ivideo_submit.py
+++ b/examples/ivideo_submit.py
@@ -1,0 +1,97 @@
+import os
+import asyncio
+from bilibili_api import video, Credential
+import re
+from best_story import Oscar
+import json
+import time
+
+SESSDATA = "记得填"
+BILI_JCT = "记得填"
+BUVID3 = "记得填"
+
+
+def reform_videos(videos):
+  video_objs = {}
+  for v in videos:
+    video_objs[v["title"]] = v 
+  return video_objs
+
+async def save_tree(bvid):
+  # 实例化 Credential 类
+  credential = Credential(sessdata=SESSDATA, bili_jct=BILI_JCT, buvid3=BUVID3)
+
+  # 实例化 Video 类
+  v = video.Video(bvid=bvid, credential=credential)
+
+  # 查询交互视频信息
+  info = await v.get_interactive_video_list()
+  vobjs = reform_videos(info["videos"])
+  aid = info["videos"][0]["aid"]
+
+  # 自定义一个情节树
+  g = Oscar(videos=vobjs, aid=aid)
+  g.gen_simple_graph(root_title="root") # pick one video title 
+  g.graph.pretty_print()
+  story = json.dumps({"graph": g.graph._serialize()})
+  #print(story)
+  
+  # 上传情节树
+  graph_result = await v.save_story_tree(story)
+  return graph_result
+
+
+UPLOAD_CONFIG = {
+  "copyright": 1, #"1 自制，2 转载。",
+  "source": "", #"str, 视频来源。投稿类型为转载时注明来源，为原创时为空。",
+  "desc": "", #"str, 视频简介。",
+  "desc_format_id": 0,
+  "dynamic": "", #"str, 动态信息。",
+  "interactive": 1,
+  "open_elec": 0, #"int, 是否展示充电信息。1 为是，0 为否。",
+  "no_reprint": 1, #"int, 显示未经作者授权禁止转载，仅当为原创视频时有效。1 为启用，0 为关闭。",
+  "subtitles": {
+    "lan": "", #"字幕语言，不清楚作用请将该项设置为空",
+    "open": 0
+  },
+  "tag": "学习,测试", #"str, 视频标签。使用英文半角逗号分隔的标签组。示例：标签1,标签2,标签3",
+  "tid": 208, #"int, 分区ID。可以使用 channel 模块进行查询。",
+  #"title": "jump jump jump", #"视频标题",
+  "up_close_danmaku": False, #"bool, 是否关闭弹幕。",
+  "up_close_reply": False, #"bool, 是否关闭评论。",
+}
+
+async def upload_videos(video_dir, cover_img, title):
+  # 上传多P视频到互动视频
+  cover = open(cover_img, "r+b")
+
+  videos = []
+  for filename in os.listdir(video_dir):
+    if filename.endswith(".mp4"): 
+      video_file = os.path.join(video_dir, filename)
+      print(video_file)
+      videos.append(video.VideoUploaderPageObject(video_stream=open(video_file, "r+b"), title=filename.split(".")[0]))
+
+  config = UPLOAD_CONFIG
+  config["title"] = title
+
+  credential = Credential(sessdata=SESSDATA, bili_jct=BILI_JCT, buvid3=BUVID3)
+
+  uploader = video.VideoUploader(cover=cover, cover_type="jpg", pages=videos, config=config, credential=credential) 
+
+  info =  await uploader.start()
+
+  return info
+
+if __name__ == '__main__':
+  folder = "directory contains video files" # 记得填
+  img = "image file path" # 记得填
+  title = "interactive video name" # 记得填
+
+  info = asyncio.get_event_loop().run_until_complete(upload_videos(folder, img, title))
+  print(info) # {"bvid": "ssssss", "aid": ddddddd}
+  bvid = info["bvid"]
+  time.sleep(120) # 为了 B 站视频编码的时间, 躺平 2 分钟
+  graph_result = asyncio.get_event_loop().run_until_complete(save_tree(bvid))
+  print(graph_result) # 成功之后，编辑树会延迟，不超过5分钟。 如果觉得有问题，就再执行一次上个存树的命令, 这时多半立即执行，推测是队列机制。
+  


### PR DESCRIPTION
* Add two APIs of Video: `get_interactive_video_list` and `save_story_tree`
* Add example for manipulation of interactive video, e.g, uploading, creating story graph, submitting story graph
* Note:
  * Check [B 站情节树构建](https://github.com/phigrey/bilibili-storytree) when using story graph.
  * Since `bilibili-storytree.StoryGraph` is Loosely coupled with this `bilibili-api`, it is safe for `bilibili-api`.